### PR TITLE
Update AnimalAI repo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ Environments are listed alphabetically.
         <img src='media/animalai.gif' width=250 />
       </td>
       <td width='50%'>
-        <a href='https://github.com/beyretb/AnimalAI-Olympics'>Animal-AI Testbed</a>
+        <a href='https://github.com/Kinds-of-Intelligence-CFI/animal-ai'>Animal-AI Testbed</a>
         <ul>
           <li>
             900 tasks reflecting various cognitive skills of animals.


### PR DESCRIPTION
Thanks for the nice list!

Small link change:

The current AnimalAI link points to an old stale repo (v2; https://github.com/beyretb/AnimalAI-Olympics)

I've updated the link so that it points to the current version of AnimalAI (v3; https://github.com/Kinds-of-Intelligence-CFI/animal-ai)